### PR TITLE
Correct Istec issuing organization in RU and UA versions

### DIFF
--- a/_includes/ru/miscellaneous/digital_certificate_obtain.md
+++ b/_includes/ru/miscellaneous/digital_certificate_obtain.md
@@ -53,8 +53,8 @@
 
 **Способ #5**
 
-Оформить сертификат через [Istec](https://www.accv.es/){:target="_blank"} (Infraestructures i Serveis de 
-Telecomunicacions i Certificació от мэрии Валенсии), онлайн и (пока) бесплатно.
+Оформить сертификат через [Istec](https://www.accv.es/){:target="_blank"} (Infraestructures i Serveis de
+Telecomunicacions i Certificació от Правительства Валенсийского сообщества), онлайн и (пока) бесплатно.
 
 1. Открыть сайт на мобильном телефоне, создать заявку.
 2. Сфотографировать TIE и сделать видео-селфи.

--- a/_includes/ua/miscellaneous/digital_certificate_obtain.md
+++ b/_includes/ua/miscellaneous/digital_certificate_obtain.md
@@ -52,7 +52,7 @@
 
 **Спосіб №5**
 
-Оформити сертифікат через [Istec](https://www.accv.es/){:target="_blank"} (Infraestructures i Serveis de Telecomunicacions i Certificació від мерії Валенсії), онлайн і (поки що) безкоштовно.
+Оформити сертифікат через [Istec](https://www.accv.es/){:target="_blank"} (Infraestructures i Serveis de Telecomunicacions i Certificació від Уряду Валенсійської спільноти), онлайн і (поки що) безкоштовно.
 	1.	Відкрити сайт на мобільному телефоні та створити заявку.
 	2.	Сфотографувати TIE і записати відео-селфі.
 	3.	Дочекатися схвалення на e-mail протягом 1–2 днів і діяти за інструкцією.


### PR DESCRIPTION
Change "city hall of Valencia" to "Government of Valencian Community" for accurate representation of Istec certificate issuer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)